### PR TITLE
MTN: Explicitly check against null

### DIFF
--- a/src/Api/Resizer.php
+++ b/src/Api/Resizer.php
@@ -429,7 +429,7 @@ class Resizer
         $this->tmpImagePath = TEMP_FOLDER . '/resampled-' . mt_rand(100000, 999999) . '.' . $file->getExtension();
 
         $this->tmpImageContent = $this->transformed->getImageResource();
-        if ($this->tmpImageContent) {
+        if ($this->tmpImageContent !== null) {
 
             // write to tmp file
             @file_put_contents($this->tmpImagePath, $this->tmpImageContent);


### PR DESCRIPTION
For some reason, $this->tmpImageContent is acting "falsey" here on some servers (but not locally), even when it exists and is usable. It will work in those circumstances if we explicitly check against null, rather than just what it evaulates to as a boolean.